### PR TITLE
Diretorio e caminho de páginas do cabeçalho das paginas principais co…

### DIFF
--- a/pages/editais/cadastroVagasEmprego.html
+++ b/pages/editais/cadastroVagasEmprego.html
@@ -62,7 +62,7 @@
                             </ul> 
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagEdital.html">Edital</a>
+                            <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagEdital.php">Edital</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagDemanda.html">Demanda</a>

--- a/pages/editais/pagBancoTalentos.html
+++ b/pages/editais/pagBancoTalentos.html
@@ -64,7 +64,7 @@
                             </ul> 
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagEdital.html">Edital</a>
+                            <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagEdital.php">Edital</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagDemanda.html">Demanda</a>

--- a/pages/editais/pagDemanda.html
+++ b/pages/editais/pagDemanda.html
@@ -67,7 +67,7 @@
                             </ul> 
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagEdital.html">Edital</a>
+                            <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagEdital.php">Edital</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link active ms-2 me-2" aria-current="page" href="./pagDemanda.html">Demanda</a>

--- a/pages/fabricas/pagFabricaAudioVisual.php
+++ b/pages/fabricas/pagFabricaAudioVisual.php
@@ -51,7 +51,7 @@
                         </ul> 
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.html">Edital</a>
+                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.php">Edital</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagDemanda.html">Demanda</a>

--- a/pages/fabricas/pagFabricaCgi.php
+++ b/pages/fabricas/pagFabricaCgi.php
@@ -53,7 +53,7 @@ include "../../app/session/fabricas/conexaoCarrosselCGI.php"
                         </ul> 
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.html">Edital</a>
+                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.php">Edital</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagDemanda.html">Demanda</a>

--- a/pages/fabricas/pagFabricaJogos.php
+++ b/pages/fabricas/pagFabricaJogos.php
@@ -53,7 +53,7 @@ include "../../app/session/fabricas/conexaoCarrosselJogos.php"
                         </ul> 
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.html">Edital</a>
+                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.php">Edital</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagDemanda.html">Demanda</a>

--- a/pages/fabricas/pagFabricaSoftware.php
+++ b/pages/fabricas/pagFabricaSoftware.php
@@ -53,7 +53,7 @@ include "../../app/session/fabricas/conexaoCarrosselSoftware.php"
                         </ul> 
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.html">Edital</a>
+                        <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagEdital.php">Edital</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link active ms-2 me-2" aria-current="page" href="../editais/pagDemanda.html">Demanda</a>


### PR DESCRIPTION
…nsertadas

O erro padrão consistia principalmente na parte do edital, páginas como as da fabricas e demandas não conseguiam acessar o edital pois o diretorio estava errado.