### PR TITLE
Bug fix/centralizar nome foto carrosel

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -759,6 +759,35 @@ nav.home li:hover ul#menuFabricas {
     text-align: justify;
 }
 
+.modal-header {
+    display: flex; 
+    justify-content: center; 
+    align-items: center; 
+    position: relative;
+    width: 100%; /* Garante que o contêiner ocupe toda a largura disponível */
+    padding: 1rem;
+}
+
+/* Estilo para o h1 com classes modal-title e fs-5 */
+h1.modal-title.fs-5 {
+    font-size: 24px; 
+    font-weight: bold; 
+    margin: 0; 
+    flex-grow: 1; /* Permite que o título ocupe o espaço disponível */
+    text-align: center; /* Garante que o texto do título esteja centralizado */
+}
+
+/* Estilo para o botão de fechamento */
+.btn-close {
+    position: absolute; /* Posição absoluta dentro do contêiner pai */
+    right: 1rem; 
+    top: 50%; 
+    transform: translateY(-50%);
+}
+
+
+
+
 div.carousel-item h5{
     font-size: 27px;
 }
@@ -880,7 +909,7 @@ div.carousel-item img#carouselImg{
 /*Fim Fábricas*/
 
 
-/* Começo da Fábrca de Software */
+/* Começo da Fábrica de Software */
 
 .bodyFabricaSoftware h1{
     font-weight: bold;
@@ -965,6 +994,33 @@ div.carousel-item img#carouselImg{
 .modal-body {
     text-align: justify;
 }
+
+.modal-header {
+    display: flex;
+    justify-content: center;
+    align-items: center; 
+    position: relative; 
+    width: 100%; /* Garante que o contêiner ocupe toda a largura disponível */
+    padding: 1rem; 
+}
+
+/* Estilo para o h1 com classes modal-title e fs-5 */
+h1.modal-title.fs-5 {
+    font-size: 24px; 
+    font-weight: bold; 
+    margin: 0; 
+    flex-grow: 1;
+    text-align: center; 
+}
+
+/* Estilo para o botão de fechamento */
+.btn-close {
+    position: absolute;
+    right: 1rem;
+    top: 50%; 
+    transform: translateY(-50%); 
+}
+
 
 div.carousel-item h5{
     font-size: 27px;

--- a/pages/fabricas/pagFabricaSoftware.php
+++ b/pages/fabricas/pagFabricaSoftware.php
@@ -154,7 +154,7 @@ include "../../app/session/fabricas/conexaoCarrosselSoftware.php"
                           <div class="modal-content">
                             <div class="modal-header">
                                 <h1 class="modal-title fs-5" id="exampleModalLabel"><?php echo $retorno["titulo"];?></h1>
-                              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                             </div>
                             <div class="modal-body">
                               <div class="container">


### PR DESCRIPTION
O texto do nome do projeto foi alinhado devidamente ao seu centro. As alterações foram principalmente em CSS e foram criadas 3 blocos de códigos em Fábricas e Fábrica de Software. 

A única alteração em HTML foi referente a um pulo de paragrafo no btn-close em modal-header para encaixar devidamente a div.

A solução era que o texto não conseguia ser alinhado pois ele não conseguia sobrepor um espaço grande que o container do btn de fechar ocupava, então o espaço do button foi reduzido e enfim o h1 foi ao seu centro.