### PR TITLE
Adicionado quadradoRoxo na tela Cadastro Aluno PSG

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1640,6 +1640,12 @@ main.body-banco-talentos {
 
 /*Cadastro  aluno psg*/
 
+#quadradoRoxo-cadastroaluno {
+    background-color: #281358;
+    border-radius: 10px;
+    text-align: center;
+}
+
 main.body-aluno-psg {
     max-width: 1300px;
     margin: 20px auto;


### PR DESCRIPTION
A única implementação foi um CSS na seção de Cadastro Aluno PSG com nome quadradoRoxo-cadastroaluno, replicado o CSS das demais páginas.