### PR TITLE
Alinhado á esquerda feito

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -37,6 +37,7 @@ header.cabecalhoGeral {
     left: 0;
     right: 0;
     top: 0;
+
 }
 
 .cabecalhoGeral {
@@ -57,8 +58,11 @@ header.cabecalhoGeral {
     height: 50px;
 }
 
-.offcanvas-title{
-    margin-left:86%;
+.offcanvas-title {
+    text-align: left;     
+    margin-bottom: 0;   
+    font-size: 16px !important ; 
+    font-weight: normal !important;
 }
 
 .cabecalhoGeral .bg-dropDown-header {


### PR DESCRIPTION
Alteração apenas no CSS implementando o texto alinhado á esquerda. O CSS alterou o alinhamento de todas as páginas, entretanto, a página Editar Carrosel estava com uma padronização errada. Para solução, foi utilizada o font-size para ser parecida com o resto das páginas e o font weight para retirar a fonte negrito que antes tinha.